### PR TITLE
Generate stable RDash output

### DIFF
--- a/packages/dom/src/Data/DataSourceItem.ts
+++ b/packages/dom/src/Data/DataSourceItem.ts
@@ -17,7 +17,7 @@ export class DataSourceItem extends SchemaType {
         this.schemaTypeName = SchemaTypeNames.DataSourceItemType;
 
         //if there is a title, then the end user created this DataSourceItem via the API (instead of the JSON parser)
-        //only in that case, we need to create a DataSource for the new DataSourceItem
+        //only in that case, we need to create a DataSource for the new DataSourceItem if it isn't provided already
         if (title) { 
             this.initialize(dataSource ?? new DataSource, title ?? "");
         }

--- a/packages/dom/src/Data/DataSourceItem.ts
+++ b/packages/dom/src/Data/DataSourceItem.ts
@@ -15,7 +15,10 @@ export class DataSourceItem extends SchemaType {
     constructor(title?: string, dataSource?: DataSource) {
         super();
         this.schemaTypeName = SchemaTypeNames.DataSourceItemType;
-        if (title) {
+
+        //if there is a title, then the end user created this DataSourceItem via the API (instead of the JSON parser)
+        //only in that case, we need to create a DataSource for the new DataSourceItem
+        if (title) { 
             this.initialize(dataSource ?? new DataSource, title ?? "");
         }
     }

--- a/packages/dom/src/Data/DataSourceItem.ts
+++ b/packages/dom/src/Data/DataSourceItem.ts
@@ -15,7 +15,9 @@ export class DataSourceItem extends SchemaType {
     constructor(title?: string, dataSource?: DataSource) {
         super();
         this.schemaTypeName = SchemaTypeNames.DataSourceItemType;
-        this.initialize(dataSource ?? new DataSource, title ?? "");
+        if (title) {
+            this.initialize(dataSource ?? new DataSource, title ?? "");
+        }
     }
 
     @JsonProperty("Id")

--- a/packages/dom/src/Visualizations/Settings/GridVisualizationSettingsBase.ts
+++ b/packages/dom/src/Visualizations/Settings/GridVisualizationSettingsBase.ts
@@ -45,6 +45,6 @@ export abstract class GridVisualizationSettingsBase extends VisualizationSetting
         this.style.textAlignment = value;
     }
 
-    @JsonProperty("Style")
+    @JsonProperty("Style", { type: GridVisualizationStyle })
     protected style: GridVisualizationStyle = new GridVisualizationStyle();
 }


### PR DESCRIPTION
This PR fixes the following two issues, making sure that after deserializing and then serializing the same dashboard using the DOM library the results are the same.

- Fix deserialization/serialization of the VisualizationSettings in the RDash file
- Prevent the inclusion of empty EXCELLOCALFILEPROVIDER DataSources in the output RDash