### PR TITLE
Support Reveal SDK 2.0 via an injected, SDK-free adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,131 @@
 # Reveal DOM for TypeScript
 
-Coming soon...
+`@revealbi/dom` lets you create, manipulate, and serialize Reveal `.rdash` dashboard
+documents as plain TypeScript objects — in the browser or in Node. It has **no direct
+dependency on the Reveal SDK**: you can build and serialize dashboards entirely from
+JSON, and opt in to the SDK only when you need to render a dashboard in a `RevealView`
+or read one back from a live `RVDashboard`.
+
+## Installation
+
+```bash
+npm install @revealbi/dom
+```
+
+To render dashboards (or load them from a Reveal server) you also need the Reveal client SDK:
+
+```bash
+npm install reveal-sdk
+```
+
+## Reveal SDK 2.0 & the adapter
+
+Reveal SDK 2.0 replaced the legacy jQuery `$.ig` global with a real package
+(`reveal-sdk`, ESM) and a `Reveal` global (script tag). `@revealbi/dom` never imports
+the SDK directly — instead you **register** it once, and the DOM's `load()` /
+`toRVDashboard()` bridge methods use whatever you registered. This keeps the DOM
+SDK-agnostic (and fully usable in Node with no SDK at all) while keeping the same
+`RdashDocument` API existing apps already use.
+
+### NPM / ESM
+
+```ts
+import * as RevealSdk from "reveal-sdk";
+import { registerRevealSdk } from "@revealbi/dom";
+
+// once, at application startup
+registerRevealSdk(RevealSdk);
+RevealSdk.RevealSdkSettings.setBaseUrl("https://your-reveal-server/");
+```
+
+### Script tag / CDN (IIFE)
+
+Load the SDK and the DOM as globals — `Reveal` and `RevealDom`. The DOM
+**auto-detects** the `Reveal` global, so no `registerRevealSdk` call is needed:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/reveal-sdk/dist/reveal-sdk.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@revealbi/dom/index.iife.js"></script>
+<script>
+  (async () => {
+    Reveal.RevealSdkSettings.setBaseUrl("https://your-reveal-server/");
+
+    const doc  = await RevealDom.RdashDocument.load("Sales");
+    const view = new Reveal.RevealView("#viewer");
+    view.dashboard = await doc.toRVDashboard();
+  })();
+</script>
+```
+
+> **CDN ESM note:** if you load the SDK from its ESM URL (`reveal-sdk.esm.js`) it
+> sets no global, so the DOM can't auto-detect it — call
+> `registerRevealSdk(RevealSdk)` explicitly with the imported namespace.
+
+## Working with dashboards
+
+### Build a dashboard and render it
+
+```ts
+import { RdashDocument } from "@revealbi/dom";
+
+const doc = new RdashDocument("My Dashboard");
+// ...add data sources & visualizations...
+
+const rv   = await doc.toRVDashboard();        // RdashDocument -> RVDashboard
+const view = new RevealView("#viewer");
+view.dashboard = rv;
+```
+
+### Load an existing dashboard, edit it, render it
+
+```ts
+const doc = await RdashDocument.load("Sales"); // by id from the Reveal server
+doc.title = "Sales (edited)";
+view.dashboard = await doc.toRVDashboard();
+```
+
+`RdashDocument.load()` accepts a dashboard **id**, an `.rdash` **`Blob`**, or a live
+**`RVDashboard`** instance.
+
+### JSON & files — no SDK required
+
+These run anywhere (Node or browser) with no SDK registered:
+
+```ts
+const doc  = RdashDocument.loadFromJson(jsonString);
+const doc2 = await RdashDocument.loadFromBuffer(rdashBytes);
+
+const json = doc.toJson();         // object
+const text = doc.toJsonString();   // string
+const blob = doc.toBlob();         // .rdash Blob
+```
+
+## Upgrading from 1.x
+
+| | 1.x | 2.0 |
+|---|---|---|
+| SDK delivery | `<script>` → `$.ig` global | `reveal-sdk` (NPM/ESM) or `Reveal` global (IIFE) |
+| Wiring | implicit (DOM reached `$.ig`) | `registerRevealSdk(RevealSdk)` once at startup |
+| `RdashDocument.load()` / `toRVDashboard()` | — | **unchanged** |
+| DOM script-tag global | `window.dom` | `window.RevealDom` |
+
+The only change for your dashboard code is a one-time `registerRevealSdk(...)` when you
+use the SDK via NPM/ESM — or nothing at all when you use the script-tag globals (the
+`Reveal` global is auto-detected). Your `load()` / `toRVDashboard()` call sites do not
+change.
+
+### Custom adapter (advanced)
+
+`registerRevealSdk` accepts the `reveal-sdk` namespace, or a custom object implementing
+`RevealSdkAdapter` if you need full control over how dashboards are loaded and converted:
+
+```ts
+import { registerRevealSdk, RevealSdkAdapter } from "@revealbi/dom";
+
+const adapter: RevealSdkAdapter = {
+  loadDashboardById:       (id)   => /* ... */,
+  createDashboardFromJson: (json) => /* ... */,
+  dashboardToJson:         (rv)   => /* ... */,
+};
+registerRevealSdk(adapter);
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "dependencies": {
         "express": "~4.18.1",
         "fflate": "^0.8.2",
+        "reveal-sdk": "^2.0.0",
         "reveal-sdk-node": "^1.8.1-rc.1",
         "tslib": "^2.3.0"
       },
@@ -15952,6 +15953,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reveal-sdk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reveal-sdk/-/reveal-sdk-2.0.0.tgz",
+      "integrity": "sha512-6Qhaf7J1mSSIv/g3vgxvWkXN2FPuMORziE9q0+G8IaVfHRmLm7dSS2e+uQChDqUCtgc4AcjYV+MmahNkdsVJSA==",
+      "hasInstallScript": true,
+      "license": "See license file in root."
+    },
     "node_modules/reveal-sdk-node": {
       "version": "1.8.1-rc.1",
       "resolved": "https://registry.npmjs.org/reveal-sdk-node/-/reveal-sdk-node-1.8.1-rc.1.tgz",
@@ -19745,7 +19753,7 @@
     },
     "packages/dom": {
       "name": "@revealbi/dom",
-      "version": "0.2.23",
+      "version": "0.2.25",
       "dependencies": {
         "fflate": "^0.8.2",
         "reflect-metadata": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "express": "~4.18.1",
     "fflate": "^0.8.2",
+    "reveal-sdk": "^2.0.0",
     "reveal-sdk-node": "^1.8.1-rc.1",
     "tslib": "^2.3.0"
   },

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@revealbi/dom",
-  "version": "0.2.25",
+  "version": "0.3.0",
   "type": "module",
   "main": "./index.js",
   "module": "./index.mjs",
   "types": "./index.d.ts",
-  "unpkg": "./index.umd.js",
-  "jsdelivr": "./index.umd.js",
+  "unpkg": "./index.iife.js",
+  "jsdelivr": "./index.iife.js",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/packages/dom/src/Core/Utilities/RevealSdkAdapter.ts
+++ b/packages/dom/src/Core/Utilities/RevealSdkAdapter.ts
@@ -1,0 +1,96 @@
+/**
+ * The minimal set of Reveal SDK operations the DOM needs in order to bridge
+ * between an `RdashDocument` and the SDK's runtime `RVDashboard`.
+ *
+ * `@revealbi/dom` never imports `reveal-sdk`. A consumer registers an
+ * implementation via {@link registerRevealSdk} (or, for script-tag / UMD usage,
+ * the DOM auto-detects the global `Reveal`). Everything is duck-typed as
+ * `unknown` so the DOM keeps no named reference to the SDK or its types.
+ */
+export interface RevealSdkAdapter {
+    /** Loads a dashboard from the server by id/name. Returns an `RVDashboard`. */
+    loadDashboardById(id: string): Promise<unknown>;
+    /** Builds an `RVDashboard` from a parsed rdash JSON object. */
+    createDashboardFromJson(json: object): unknown | Promise<unknown>;
+    /** Serializes an `RVDashboard` back to a parsed rdash JSON object. */
+    dashboardToJson(rvDashboard: unknown): unknown | Promise<unknown>;
+}
+
+/**
+ * Something shaped like the Reveal SDK namespace — i.e. the result of
+ * `import * as RevealSdk from "reveal-sdk"`, or the global `Reveal`. Duck-typed
+ * so the DOM never names the SDK's types.
+ */
+type RevealSdkLike = any;
+
+let registeredAdapter: RevealSdkAdapter | undefined;
+
+/**
+ * Registers the Reveal SDK (or a custom adapter) used by the DOM's
+ * `RdashDocument.load()` and `RdashDocument.toRVDashboard()` bridge methods.
+ * Call once at application startup, before loading or converting dashboards.
+ *
+ * Pass the SDK namespace:
+ * ```ts
+ * import * as RevealSdk from "reveal-sdk";
+ * registerRevealSdk(RevealSdk);
+ * ```
+ * Script-tag / UMD consumers can skip this — the DOM auto-detects the global
+ * `Reveal`. Pass an object implementing {@link RevealSdkAdapter} to fully
+ * override the default behavior.
+ */
+export function registerRevealSdk(sdkOrAdapter: RevealSdkLike | RevealSdkAdapter): void {
+    registeredAdapter = isAdapter(sdkOrAdapter) ? sdkOrAdapter : toAdapter(sdkOrAdapter);
+}
+
+/**
+ * @internal Resolves the active adapter. Resolution order:
+ *   1. an adapter registered via {@link registerRevealSdk};
+ *   2. the global `Reveal` (script-tag / UMD consumers), wrapped on the fly;
+ *   3. otherwise throws with guidance.
+ *
+ * Reading `globalThis.Reveal` is a guarded global lookup, not an
+ * `import "reveal-sdk"` — it never runs the SDK at module load, never forces the
+ * dependency on every consumer, and is simply absent (→ throw) under Node.
+ */
+export function getRevealSdkAdapter(): RevealSdkAdapter {
+    if (registeredAdapter) {
+        return registeredAdapter;
+    }
+
+    const globalReveal = (globalThis as any).Reveal;
+    if (globalReveal) {
+        return toAdapter(globalReveal);
+    }
+
+    throw new Error(
+        "Reveal SDK is not available. Register it once at startup with " +
+        'registerRevealSdk(RevealSdk) (import * as RevealSdk from "reveal-sdk"), ' +
+        "or include the Reveal SDK script so the global `Reveal` is present."
+    );
+}
+
+function isAdapter(value: any): value is RevealSdkAdapter {
+    return !!value
+        && typeof value.loadDashboardById === "function"
+        && typeof value.createDashboardFromJson === "function"
+        && typeof value.dashboardToJson === "function";
+}
+
+/**
+ * Wraps an SDK-like object into a {@link RevealSdkAdapter}. Prefers the public
+ * API planned for a future SDK release (`RVDashboard.loadFromJson` /
+ * `RVDashboard.toJson`) and falls back to the current 2.0 entry points, so the
+ * same DOM build keeps working as the SDK evolves — no DOM change on SDK release.
+ */
+function toAdapter(sdk: RevealSdkLike): RevealSdkAdapter {
+    return {
+        loadDashboardById: (id: string) => sdk.RVDashboard.loadDashboard(id),
+        createDashboardFromJson: (json: object) =>
+            sdk.RVDashboard?.loadFromJson?.(json)
+            ?? sdk.RevealUtility.createDashboardFromJsonObject(json),
+        dashboardToJson: (rvDashboard: any) =>
+            rvDashboard?.toJson?.()
+            ?? rvDashboard?._dashboardModel?._dashboardModel?.toJson(),
+    };
+}

--- a/packages/dom/src/Core/Utilities/RvDashboardLoader.ts
+++ b/packages/dom/src/Core/Utilities/RvDashboardLoader.ts
@@ -1,61 +1,48 @@
 import { RdashDocument } from "../../RdashDocument";
 import { RdashSerializer } from "../Serialization/RdashSerializer";
-import { isBrowserEnvironment } from "./Environment";
+import { getRevealSdkAdapter } from "./RevealSdkAdapter";
 
-declare let $: any;
-
+/**
+ * Internal bridge between `RdashDocument` and the Reveal SDK. All SDK access goes
+ * through the registered {@link RevealSdkAdapter}; this class never references the
+ * SDK directly (no `import "reveal-sdk"`, no `$.ig`/`Reveal` global).
+ */
 export class RvDashboardLoader {
 
+    /**
+     * Resolves the input to an `RVDashboard` instance, loading via the registered
+     * SDK adapter when given an id, or unzipping a Blob, as needed.
+     */
     static async load(dashboard?: string | Blob | RdashDocument | unknown): Promise<any | null> {
-
         if (!dashboard) {
             return null;
         }
 
-        if (typeof dashboard === "string" || dashboard instanceof Blob) {
-            return await this.loadRVDashboard(dashboard);
+        if (typeof dashboard === "string") {
+            return await getRevealSdkAdapter().loadDashboardById(dashboard);
+        }
+
+        if (dashboard instanceof Blob) {
+            const json = await RdashSerializer.blobToJson(dashboard);
+            return await this.loadRVDashboardFromJson(json);
         }
 
         if (dashboard instanceof RdashDocument) {
             return await dashboard.toRVDashboard();
         }
 
-        if (dashboard.constructor.name === "RVDashboard") {
-            return dashboard;
-        }
-
-        if (dashboard.hasOwnProperty("_dashboardModel")) {
-            return dashboard;
-        }
-
-        throw new Error("Invalid Dashboard provided to DashboardLoader.load");
-    }
-
-    private static async loadRVDashboard(input: string | Blob): Promise<unknown> {
-        this.ensureRevealSdkLoaded();
-        if (typeof input === 'string') {
-            return await $.ig.RVDashboard.loadDashboard(input);
-        } else {
-            const json = await RdashSerializer.blobToJson(input);
-            return await this.loadRVDashboardFromJson(json);
-        }
-    }
-
-    static async loadRVDashboardFromJson(json: string): Promise<unknown> {
-        this.ensureRevealSdkLoaded();
-        const parsedJson = JSON.parse(json);
-        const dashboard = await $.ig.RevealUtility.createDashboardFromJsonObject(parsedJson);
+        // Assume it's already an `RVDashboard` instance. Duck-typed on purpose: a
+        // `constructor.name === "RVDashboard"` check breaks under minification.
         return dashboard;
     }
 
-    private static ensureRevealSdkLoaded(): void {
-        if (!isBrowserEnvironment) {
-            throw new Error("This function must be run in a browser environment.");
-        }
-    
-        if (!(window as any).$?.ig?.RevealSdkSettings) {
-            throw new Error("Reveal SDK is not loaded. Please make sure to include the Reveal SDK in your project.");
-        }
+    /** Builds an `RVDashboard` from rdash JSON text via the registered SDK adapter. */
+    static async loadRVDashboardFromJson(json: string): Promise<unknown> {
+        return await getRevealSdkAdapter().createDashboardFromJson(JSON.parse(json));
+    }
+
+    /** Serializes an `RVDashboard` back to rdash JSON via the registered SDK adapter. */
+    static async dashboardToJson(rvDashboard: unknown): Promise<unknown> {
+        return await getRevealSdkAdapter().dashboardToJson(rvDashboard);
     }
 }
-

--- a/packages/dom/src/Core/Utilities/index.ts
+++ b/packages/dom/src/Core/Utilities/index.ts
@@ -1,2 +1,4 @@
 export { RvDashboardLoader } from "./RvDashboardLoader";
 export { VisualizationConverter } from "./VisualizationConverter";
+export { registerRevealSdk, getRevealSdkAdapter } from "./RevealSdkAdapter";
+export type { RevealSdkAdapter } from "./RevealSdkAdapter";

--- a/packages/dom/src/RdashDocument.ts
+++ b/packages/dom/src/RdashDocument.ts
@@ -114,18 +114,16 @@ export class RdashDocument {
             throw new Error("dashboard cannot be null or undefined");
         }
 
-        let dashboardJson;
+        let dashboardJson: string | Record<string, any>;
 
         if (dashboard instanceof Blob) {
-            console.log("Loading RdashDocument from Blob");
             dashboardJson = await RdashSerializer.blobToJson(dashboard);
         } else {
             const loadedDashboard = await RvDashboardLoader.load(dashboard);
             if (!loadedDashboard) {
                 throw new Error("Could not load dashboard");
             }
-            console.log("Loading RdashDocument from RVDashboard");
-            dashboardJson = loadedDashboard._dashboardModel._dashboardModel.toJson(); //todo: improve this in SDK
+            dashboardJson = await RvDashboardLoader.dashboardToJson(loadedDashboard) as string | Record<string, any>;
         }
 
         return RdashSerializer.deserialize(dashboardJson);

--- a/packages/dom/src/RdashDocument.ts
+++ b/packages/dom/src/RdashDocument.ts
@@ -117,13 +117,15 @@ export class RdashDocument {
         let dashboardJson;
 
         if (dashboard instanceof Blob) {
+            console.log("Loading RdashDocument from Blob");
             dashboardJson = await RdashSerializer.blobToJson(dashboard);
         } else {
             const loadedDashboard = await RvDashboardLoader.load(dashboard);
             if (!loadedDashboard) {
                 throw new Error("Could not load dashboard");
             }
-            dashboardJson = loadedDashboard._dashboardModel.__dashboardModel.toJson(); //todo: improve this in SDK
+            console.log("Loading RdashDocument from RVDashboard");
+            dashboardJson = loadedDashboard._dashboardModel._dashboardModel.toJson(); //todo: improve this in SDK
         }
 
         return RdashSerializer.deserialize(dashboardJson);
@@ -165,6 +167,14 @@ export class RdashDocument {
      */
     toBlob(): Blob {
         return RdashSerializer.toBlob(this);
+    }
+
+    /**
+     * Converts the `RdashDocument` to a JSON object representation of the contents of the RDASH file.
+     * @returns A JSON object representation of the contents of the RDASH file. 
+     */
+    toJson(): object {
+        return JSON.parse(RdashSerializer.serialize(this));
     }
 
     /**

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -5,3 +5,5 @@ export * from "./Filters";
 export * from "./Primitives";
 export * from "./Visualizations";
 export { RdashDocument } from "./RdashDocument";
+export { registerRevealSdk } from "./Core/Utilities/RevealSdkAdapter";
+export type { RevealSdkAdapter } from "./Core/Utilities/RevealSdkAdapter";

--- a/packages/dom/vite.config.ts
+++ b/packages/dom/vite.config.ts
@@ -33,11 +33,13 @@ export default defineConfig({
     lib: {
       // Could also be a dictionary or array of multiple entry points.
       entry: 'src/index.ts',
-      name: 'dom',
-      fileName: (format) => `index.${format === 'es' ? 'mjs' : format === 'umd' ? 'umd.js' : 'js'}`,
-      // Change this to the formats you want to support.
-      // Don't forget to update your package.json as well.
-      formats: ['es', 'cjs', 'umd'],
+      // Global variable name for the IIFE (script-tag / CDN) build: `window.RevealDom`.
+      name: 'RevealDom',
+      fileName: (format) => `index.${format === 'es' ? 'mjs' : format === 'iife' ? 'iife.js' : 'js'}`,
+      // es -> bundlers/NPM, cjs -> Node require, iife -> browser <script> global.
+      // Dropped UMD: redundant with the dedicated es + cjs builds, and IIFE matches
+      // what reveal-sdk itself ships (global `Reveal`).
+      formats: ['es', 'cjs', 'iife'],
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.

--- a/samples/sandbox/src/index.html
+++ b/samples/sandbox/src/index.html
@@ -12,9 +12,5 @@
     <!-- <app-root></app-root> -->
 
     <div id="viewer" style="height: 100%;"></div>
-
-    <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
-    <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-    <script src="https://dl.revealbi.io/reveal/libs/1.8.0/infragistics.reveal.js"></script>
   </body>
 </html>

--- a/samples/sandbox/src/main.ts
+++ b/samples/sandbox/src/main.ts
@@ -1,22 +1,28 @@
 // import './app/app.element';
-import { DashboardDateFilter, GridVisualization, RdashDocument, VisualizationFilter } from "@revealbi/dom";
+import * as RevealSdk from "reveal-sdk";
+import { RevealSdkSettings, RevealView, RVDashboard, RevealUtility } from "reveal-sdk";
+import { DashboardDateFilter, GridVisualization, RdashDocument, VisualizationFilter, registerRevealSdk } from "@revealbi/dom";
 import { SqlServerDataSourceDashboard } from "./dashboards/SqlServerDataSourceDashboard";
 import { RestDataSourceDashboards } from "./dashboards/RestDataSourceDashboards";
 import { CustomDashboard } from "./dashboards/CustomDashboard";
 import { SalesDashboard } from "./dashboards/SalesDashboard";
 import { FixedLinesDashboard } from "./dashboards/features/FixedLines";
 
-declare const $: any;
+//RevealSdkSettings.setBaseUrl("https://samples.revealbi.io/upmedia-backend/reveal-api/");
+RevealSdkSettings.setBaseUrl("https://localhost:7064/");
 
-//$.ig.RevealSdkSettings.setBaseUrl("https://samples.revealbi.io/upmedia-backend/reveal-api/");
-$.ig.RevealSdkSettings.setBaseUrl("http://localhost:5111/");
+// Opt-in adapter: register the SDK once so @revealbi/dom's load()/toRVDashboard()
+// bridge to reveal-sdk without the DOM ever importing it directly.
+registerRevealSdk(RevealSdk);
 
 const loadDashboard = async () => {
 
     const viewer = document.getElementById('viewer');
     if (viewer) {
 
-        //const dashboard = await $.ig.RVDashboard.loadDashboard("Sales");
+        // const rvdashboard = await RVDashboard.loadDashboard("Sales"); //loads from server
+        // const document = await RdashDocument.load(rvdashboard);
+        // const dashboard = RevealUtility.createDashboardFromJsonObject(document.toJson());
 
         const document = await RdashDocument.load("Banking");
         document.useAutoLayout = true;
@@ -29,8 +35,8 @@ const loadDashboard = async () => {
 
         const dashboard = await document.toRVDashboard();
 
-        // const document = await SalesDashboard.createDashboard()
-        // const dashboard = await document.toRVDashboard();
+        //  const document = await SalesDashboard.createDashboard()
+        //  const dashboard = await document.toRVDashboard();
 
         //const dashboard = await CustomDashboard.createDashboard().toRVDashboard();
         //const dashboard = await SqlServerDataSourceDashboard.createDashboard().toRVDashboard();
@@ -58,11 +64,11 @@ const loadDashboard = async () => {
         // const document = await FixedLinesDashboard.createDashboard()
         //const dashboard = await document.toRVDashboard();
 
-        const revealView: any = new $.ig.RevealView(viewer);
-        revealView.onUrlLinkRequested = (args: any) => {
-            console.log(args);
-            return args.url;
-        };
+        const revealView: any = new RevealView(viewer);
+        // revealView.onUrlLinkRequested = (args: any) => {
+        //     console.log(args);
+        //     return args.url;
+        // };
         revealView.dashboard = dashboard;
     }
 

--- a/samples/sandbox/webpack.config.js
+++ b/samples/sandbox/webpack.config.js
@@ -7,6 +7,12 @@ module.exports = {
   },
   devServer: {
     port: 4200,
+    client: {
+      overlay: {
+        errors: true,
+        warnings: false,
+      },
+    },
   },
   plugins: [
     new NxAppWebpackPlugin({
@@ -20,5 +26,19 @@ module.exports = {
       outputHashing: process.env['NODE_ENV'] === 'production' ? 'all' : 'none',
       optimization: process.env['NODE_ENV'] === 'production',
     }),
+    // NxAppWebpackPlugin overwrites config.ignoreWarnings, so append ours after it.
+    // reveal-sdk ships `//# sourceMappingURL=` comments without the matching .map
+    // files; source-map-loader logs a harmless "Failed to parse source map" for each.
+    // Silence just those so they don't flood the console or block the dev-server overlay.
+    {
+      apply(compiler) {
+        // Entries must be functions here: webpack normalizes RegExp -> fn during
+        // options processing, which already ran by the time this plugin applies.
+        compiler.options.ignoreWarnings = [
+          ...(compiler.options.ignoreWarnings ?? []),
+          (warning) => /Failed to parse source map/.test(warning.message),
+        ];
+      },
+    },
   ],
 };


### PR DESCRIPTION
## Summary

Upgrades `@revealbi/dom` to work with **Reveal SDK 2.0** (TypeScript, published on NPM, with the legacy jQuery `$.ig` global removed) while keeping the DOM free of any direct/named reference to the SDK and **preserving the existing public API** for backwards compatibility.

## What changed

- **Injected SDK adapter** (`packages/dom/src/Core/Utilities/RevealSdkAdapter.ts`, new). The DOM no longer references the SDK. Consumers register it once with `registerRevealSdk(RevealSdk)`; script-tag / IIFE users are auto-detected via the global `Reveal`. Resolution order: registered adapter -> guarded `globalThis.Reveal` -> throw.
- `RvDashboardLoader` rewired off `$.ig` to delegate to the adapter. `RdashDocument.load()` / `toRVDashboard()` keep their exact signatures (backwards compatible).
- The adapter **prefers the forthcoming SDK API** (`RVDashboard.loadFromJson` / `RVDashboard.toJson`) and **falls back to current 2.0** (`RevealUtility.createDashboardFromJsonObject` and the `_dashboardModel` reach). That internal reach now lives *only* in the adapter and auto-upgrades when the SDK ships the public methods — no DOM change required.
- Added `RdashDocument.toJson(): object` for the forward feed.
- **Build:** browser bundle switched **UMD -> IIFE**; global renamed `window.dom` -> **`window.RevealDom`** (the dedicated `es` + `cjs` builds already cover bundlers/Node). `unpkg`/`jsdelivr` -> `index.iife.js`.
- **Sandbox** upgraded to SDK 2.0 via NPM/ESM and registers the adapter; `webpack.config.js` silences `reveal-sdk`'s missing-sourcemap warnings so they no longer block the dev-server overlay.
- **README** rewritten with a 2.0 upgrade guide (adapter usage, NPM vs script-tag, 1.x -> 2.0 table).
- Version bumped to **0.3.0**.

## Why

Reveal SDK 2.0 removed the `$.ig` global the DOM relied on. The adapter keeps `@revealbi/dom` SDK-agnostic — still usable in Node with no SDK at all — and lets existing customers upgrade with a single `registerRevealSdk(...)` call instead of rewriting their `load()` / `toRVDashboard()` call sites.

## Reviewer notes

- **Breaking for some consumers** (hence the 0.3.0 bump): the IIFE global is now `RevealDom` (was `dom`), and NPM/ESM consumers must call `registerRevealSdk(RevealSdk)` once at startup. Script-tag users need nothing (the `Reveal` global is auto-detected).
- **Depends on a future SDK release** adding public `RVDashboard.loadFromJson` / `toJson`; until then the adapter uses the current (`@hidden`) `createDashboardFromJsonObject` and the `_dashboardModel` fallback.
- `samples/sandbox/src/app/app.element.ts` still has a dormant, unused `$.ig` reference (not on the active code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)